### PR TITLE
fix(FIR-12030): add adapter which intialized with stringstream instead of file

### DIFF
--- a/casbin/CMakeLists.txt
+++ b/casbin/CMakeLists.txt
@@ -74,7 +74,6 @@ set(CMAKE_CXX_STANDARD 17)
 
 add_library(casbin STATIC ${CASBIN_SOURCE_FILES})
 
-target_precompile_headers(casbin PRIVATE pch.h)
 target_include_directories(casbin PRIVATE ${CASBIN_SOURCE_DIR})
 
 set_target_properties(casbin PROPERTIES 

--- a/casbin/CMakeLists.txt
+++ b/casbin/CMakeLists.txt
@@ -47,6 +47,7 @@ set(CASBIN_SOURCE_FILES
     persist/file_adapter/batch_file_adapter.cpp
     persist/file_adapter/file_adapter.cpp
     persist/file_adapter/filtered_file_adapter.cpp
+    persist/file_adapter/stringstream_adapter.cpp
     persist/adapter.cpp
     persist/default_watcher.cpp
     persist/default_watcher_ex.cpp

--- a/casbin/enforcer.cpp
+++ b/casbin/enforcer.cpp
@@ -25,6 +25,7 @@
 #include "./enforcer.h"
 #include "./persist/watcher_ex.h"
 #include "./persist/file_adapter/file_adapter.h"
+#include "./persist/file_adapter/stringstream_adapter.h"
 #include "./persist/file_adapter/batch_file_adapter.h"
 #include "./rbac/default_role_manager.h"
 #include "./effect/default_effector.h"
@@ -184,6 +185,17 @@ Enforcer ::Enforcer(const std::string& model_path, const std::string& policy_fil
 }
 
 /**
+ * Enforcer initializes an enforcer with a model file and a policy string stream.
+ *
+ * @param model_path the path of the model file.
+ * @param policy the policy string stream.
+ */
+Enforcer :: Enforcer(const std::string& model_path, std::stringstream && policy)
+    : Enforcer(std::make_shared<Model>(model_path), std::make_shared<StringstreamAdapter>(std::move(policy))) {   
+    m_model_path = model_path;
+}
+
+/**
  * Enforcer initializes an enforcer with a database adapter.
  *
  * @param model_path the path of the model file.
@@ -206,8 +218,31 @@ Enforcer::Enforcer(const std::shared_ptr<Model>& m, std::shared_ptr<Adapter> ada
 
     this->Initialize();
 
-    if (m_adapter && m_adapter->file_path != "")
-        this->LoadPolicy();
+    // load policy if needed
+    if (m_adapter)
+    {
+        // try understand if we should load policy now, this depends on a type of the adapter
+        bool loadPolicyNow = false;
+
+        /* It was better to add function ShouldLoadPolicyNow() for all adapters, 
+         * but it is too big change for this task.
+         */
+
+        // verify if it is stringstream adapter
+        auto downcastedPtr = std::dynamic_pointer_cast<StringstreamAdapter>(m_adapter);
+        if(downcastedPtr)
+        {
+            // for StringstreamAdapter we load policy if we have bytes in stream
+            loadPolicyNow = m_adapter->m_policy_stringstream.rdbuf()->in_avail() > 0;
+        } else {
+            // for other types of adapters we load policy if we have file path
+            loadPolicyNow = m_adapter->file_path != "";
+        }
+
+        if (loadPolicyNow) {
+            this->LoadPolicy();
+        }
+    }
 }
 
 /**

--- a/casbin/enforcer.cpp
+++ b/casbin/enforcer.cpp
@@ -233,10 +233,10 @@ Enforcer::Enforcer(const std::shared_ptr<Model>& m, std::shared_ptr<Adapter> ada
         if(downcastedPtr)
         {
             // for StringstreamAdapter we load policy if we have bytes in stream
-            loadPolicyNow = m_adapter->m_policy_stringstream.rdbuf()->in_avail() > 0;
+            loadPolicyNow = (m_adapter->m_policy_stringstream.rdbuf()->in_avail() > 0);
         } else {
             // for other types of adapters we load policy if we have file path
-            loadPolicyNow = m_adapter->file_path != "";
+            loadPolicyNow = (m_adapter->file_path != "");
         }
 
         if (loadPolicyNow) {

--- a/casbin/enforcer.h
+++ b/casbin/enforcer.h
@@ -66,6 +66,18 @@ class Enforcer : public IEnforcer {
          * @param policy_file the path of the policy file.
          */
         Enforcer(const std::string& model_path, const std::string& policy_file);
+
+        // Why we need 2 declarations? Asked a question:
+        // FIXME: https://github.com/casbin/casbin-cpp/issues/201
+        /**
+         * Enforcer initializes an enforcer with a model file and a policy string stream.
+         *
+         * @param model_path the path of the model file.
+         * @param policy the policy string stream.
+         */
+        Enforcer(const std::string& model_path, std::stringstream && policy);
+
+
         /**
          * Enforcer initializes an enforcer with a database adapter.
          *

--- a/casbin/persist/adapter.h
+++ b/casbin/persist/adapter.h
@@ -33,6 +33,7 @@ void LoadPolicyLine(std::string line, const std::shared_ptr<Model>& model);
 class Adapter {
     public:
 
+        std::stringstream m_policy_stringstream;
         std::string  file_path;
         bool filtered;
 

--- a/casbin/persist/file_adapter/stringstream_adapter.cpp
+++ b/casbin/persist/file_adapter/stringstream_adapter.cpp
@@ -1,0 +1,57 @@
+#include "pch.h"
+
+#include "./stringstream_adapter.h"
+#include "../../util/util.h"
+#include "../../exception/unsupported_operation_exception.h"
+
+namespace casbin {
+
+
+StringstreamAdapter :: StringstreamAdapter(std::stringstream && policy){
+    this->m_policy_stringstream = std::move(policy);
+}
+
+void StringstreamAdapter :: LoadPolicy(const std::shared_ptr<Model>& model) {
+    this->LoadPolicyStringStream(model, LoadPolicyLine);
+}
+
+void StringstreamAdapter :: LoadPolicyStringStream(const std::shared_ptr<Model>& model, 
+                                                   std::function<void(std::string, const std::shared_ptr<Model>&)> handler) { 
+    std::string line;
+    while(getline(this->m_policy_stringstream, line, '\n')){
+        line = Trim(line);
+        handler(line, model);
+    }
+
+    this->m_policy_stringstream.str(std::string());
+}
+
+
+
+void StringstreamAdapter ::SavePolicy(const std::shared_ptr<Model>& model){
+    throw UnsupportedOperationException("not implemented");
+}
+    
+void StringstreamAdapter ::AddPolicy(std::string sec, std::string p_type, std::vector<std::string> rule){
+    throw UnsupportedOperationException("not implemented");
+}
+    
+void StringstreamAdapter ::RemovePolicy(std::string sec, std::string p_type, std::vector<std::string> rule){
+    throw UnsupportedOperationException("not implemented");
+}
+    
+void StringstreamAdapter ::RemoveFilteredPolicy(std::string sec, std::string ptype, int field_index, std::vector<std::string> field_values){
+    throw UnsupportedOperationException("not implemented");
+}
+
+bool StringstreamAdapter ::IsFiltered(){
+    throw UnsupportedOperationException("not implemented");
+    return false;
+}
+
+
+
+} // namespace casbin
+
+
+

--- a/casbin/persist/file_adapter/stringstream_adapter.h
+++ b/casbin/persist/file_adapter/stringstream_adapter.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "../adapter.h"
+
+namespace casbin {
+
+class StringstreamAdapter: public Adapter {
+    public:
+
+        virtual ~StringstreamAdapter(){}
+
+        StringstreamAdapter(std::stringstream && policy);
+
+        void LoadPolicy(const std::shared_ptr<Model>& model) override;
+
+        void SavePolicy(const std::shared_ptr<Model>& model) override;
+        
+        void AddPolicy(std::string sec, std::string p_type, std::vector<std::string> rule) override;
+        
+        void RemovePolicy(std::string sec, std::string p_type, std::vector<std::string> rule) override;
+        
+        void RemoveFilteredPolicy(std::string sec, std::string ptype, int field_index, std::vector<std::string> field_values) override;
+        
+        bool IsFiltered() override;
+
+    private:
+        void LoadPolicyStringStream(const std::shared_ptr<Model>& model, 
+            std::function<void(std::string, const std::shared_ptr<Model>&)> handler);
+};
+
+} // namespace casbin

--- a/include/casbin/casbin_enforcer.h
+++ b/include/casbin/casbin_enforcer.h
@@ -186,6 +186,18 @@ namespace casbin {
          * @param policy_file the path of the policy file.
          */
         Enforcer(const std::string& model_path, const std::string& policy_file);
+
+
+        // Why we need 2 declarations? Asked a question:
+        // FIXME: https://github.com/casbin/casbin-cpp/issues/201
+        /**
+         * Enforcer initializes an enforcer with a model file and a policy string stream.
+         *
+         * @param model_path the path of the model file.
+         * @param policy the policy string stream.
+         */
+        Enforcer(const std::string& model_path, std::stringstream && policy);
+
         /**
          * Enforcer initializes an enforcer with a database adapter.
          *


### PR DESCRIPTION
Implement new type of stringstream adapter which implements the Adapter interface. This new adapter allows to load policy from stringstream and not from file. The change is not clean, if we want a clean change, required a deeper refactoring. 